### PR TITLE
Remove `Stick [Joystick]` binding from `Move`

### DIFF
--- a/Assets/Settings/Input/InputActions.inputactions
+++ b/Assets/Settings/Input/InputActions.inputactions
@@ -7,7 +7,7 @@
             "actions": [
                 {
                     "name": "Move",
-                    "type": "Value",
+                    "type": "PassThrough",
                     "id": "351f2ccd-1f9f-44bf-9bec-d62ac5c5f408",
                     "expectedControlType": "Vector2",
                     "processors": "",

--- a/Assets/Settings/Input/InputActions.inputactions
+++ b/Assets/Settings/Input/InputActions.inputactions
@@ -12,7 +12,7 @@
                     "expectedControlType": "Vector2",
                     "processors": "",
                     "interactions": "",
-                    "initialStateCheck": true
+                    "initialStateCheck": false
                 },
                 {
                     "name": "Look",

--- a/Assets/Settings/Input/InputActions.inputactions
+++ b/Assets/Settings/Input/InputActions.inputactions
@@ -7,12 +7,12 @@
             "actions": [
                 {
                     "name": "Move",
-                    "type": "PassThrough",
+                    "type": "Value",
                     "id": "351f2ccd-1f9f-44bf-9bec-d62ac5c5f408",
                     "expectedControlType": "Vector2",
                     "processors": "",
                     "interactions": "",
-                    "initialStateCheck": false
+                    "initialStateCheck": true
                 },
                 {
                     "name": "Look",

--- a/Assets/Settings/Input/InputActions.inputactions
+++ b/Assets/Settings/Input/InputActions.inputactions
@@ -193,17 +193,6 @@
                 },
                 {
                     "name": "",
-                    "id": "3ea4d645-4504-4529-b061-ab81934c3752",
-                    "path": "<Joystick>/stick",
-                    "interactions": "",
-                    "processors": "",
-                    "groups": "Joystick",
-                    "action": "Move",
-                    "isComposite": false,
-                    "isPartOfComposite": false
-                },
-                {
-                    "name": "",
                     "id": "c1f7a91b-d0fd-4a62-997e-7fb9b69bf235",
                     "path": "<Gamepad>/rightStick",
                     "interactions": "",


### PR DESCRIPTION
**Changes:**
~~`Input Type` of `Move` from the `Player InputActions` changed from `Value` to `Pass Through`. This seems to resolve bug #15 where the `PlayerActor` moves up and to the left when input is cancelled from the gamepad or keyboard, and causes `moveInputActionReference.action.canceled` in `PlayerActor` to be properly triggered when movement input stops.~~

Turns out this was an issue with my mechanical keyboard reading as a `Stick [Joystick]` and the `stick` values never reading as zero in the input debugger. Removing the `Stick [Joystick]` binding from `Move` seems to fix this, and then the `canceled` event actually gets called.

**For More Info See:**
[PlayerActor Moves without Input #15](https://github.com/ugnelis/moon-gale/issues/15)